### PR TITLE
Initialize setup popup on app start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 
+# Node packages
+node_modules/
+
 # Environment files
 .env
 .env.local

--- a/src/AppPro.tsx
+++ b/src/AppPro.tsx
@@ -15,7 +15,7 @@ export const AppPro: React.FC = () => {
   const gameRef = useRef<Phaser.Game | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentMode, setCurrentMode] = useState<'edit' | 'annotate' | 'view'>('edit');
-  const [showSetup, setShowSetup] = useState(false);
+  const [showSetup, setShowSetup] = useState(true);
   const [showExport, setShowExport] = useState(false);
   
   useEffect(() => {
@@ -75,7 +75,7 @@ export const AppPro: React.FC = () => {
       
       {/* Mode-specific Toolbar */}
       <div className="toolbar-container">
-        {currentMode === 'edit' && <EditToolbar />}
+        {currentMode === 'edit' && <EditToolbar onConfigure={() => setShowSetup(true)} />}
         {currentMode === 'annotate' && <AnnotateToolbar />}
         {currentMode === 'view' && <ViewToolbar />}
       </div>

--- a/src/components/Toolbar/EditToolbar.tsx
+++ b/src/components/Toolbar/EditToolbar.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { useStore } from '../../store';
 import './Toolbar.css';
 
-export const EditToolbar: React.FC = () => {
+interface EditToolbarProps {
+  onConfigure: () => void;
+}
+
+export const EditToolbar: React.FC<EditToolbarProps> = ({ onConfigure }) => {
   const [activeTool, setActiveTool] = useState<string>('brush');
   const [activeCS, setActiveCS] = useState<number>(1);
   const [brushRadius, setBrushRadius] = useState<number>(1);
@@ -157,7 +161,12 @@ export const EditToolbar: React.FC = () => {
       
       <div className="tool-group ml-auto">
         {/* Configure button for advanced settings */}
-        <button className="action-btn" id="configure-btn" title="Advanced Settings">
+        <button
+          className="action-btn"
+          id="configure-btn"
+          title="Advanced Settings"
+          onClick={onConfigure}
+        >
           <svg width="16" height="16" viewBox="0 0 16 16">
             <circle cx="8" cy="8" r="3" stroke="currentColor" fill="none"/>
             <path d="M8 1 L8 3 M8 13 L8 15 M1 8 L3 8 M13 8 L15 8" stroke="currentColor"/>


### PR DESCRIPTION
## Summary
- Show setup modal when the app launches
- Wire the toolbar's Configure button to reopen the setup modal
- Ignore `node_modules` in version control

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ddfe4e08c832591e8fc9f839925c0