### PR TITLE
feat: show bearings and abutments on beam canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 
+# Node packages
+node_modules/
+
 # Environment files
 .env
 .env.local

--- a/src/AppPro.tsx
+++ b/src/AppPro.tsx
@@ -15,7 +15,7 @@ export const AppPro: React.FC = () => {
   const gameRef = useRef<Phaser.Game | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentMode, setCurrentMode] = useState<'edit' | 'annotate' | 'view'>('edit');
-  const [showSetup, setShowSetup] = useState(false);
+  const [showSetup, setShowSetup] = useState(true);
   const [showExport, setShowExport] = useState(false);
   
   useEffect(() => {
@@ -75,7 +75,7 @@ export const AppPro: React.FC = () => {
       
       {/* Mode-specific Toolbar */}
       <div className="toolbar-container">
-        {currentMode === 'edit' && <EditToolbar />}
+        {currentMode === 'edit' && <EditToolbar onConfigure={() => setShowSetup(true)} />}
         {currentMode === 'annotate' && <AnnotateToolbar />}
         {currentMode === 'view' && <ViewToolbar />}
       </div>

--- a/src/components/Setup/SetupModal.tsx
+++ b/src/components/Setup/SetupModal.tsx
@@ -8,7 +8,7 @@ interface SetupModalProps {
 }
 
 export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
-  const { beam, project, setBeamProfile, setBeamLength, setBearings, setProjectInfo } = useStore();
+  const { beam, project, setBeamProfile, setBeamLength, setBearings, setBeamDimensions, setProjectInfo } = useStore();
   
   // Canvas refs for previews
   const sectionCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -29,9 +29,9 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
   const [bearingCLIn, setBearingCLIn] = useState((beam.length - 2 * beam.leftBearing) % 12);
   const [bearingDistanceFt, setBearingDistanceFt] = useState(Math.floor(beam.leftBearing / 12));
   const [bearingDistanceIn, setBearingDistanceIn] = useState(beam.leftBearing % 12);
-  const [backwallClearanceIn, setBackwallClearanceIn] = useState(2);
-  const [breastwallDistanceFt, setBreastwallDistanceFt] = useState(2);
-  const [breastwallDistanceIn, setBreastwallDistanceIn] = useState(6);
+  const [backwallClearanceIn, setBackwallClearanceIn] = useState(beam.backwallClearance);
+  const [breastwallDistanceFt, setBreastwallDistanceFt] = useState(Math.floor(beam.breastwallDistance / 12));
+  const [breastwallDistanceIn, setBreastwallDistanceIn] = useState(beam.breastwallDistance % 12);
   
   // Draw section preview
   const drawSectionPreview = () => {
@@ -146,6 +146,8 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
     const totalLength = lengthFt * 12 + lengthIn;
     const bearingCL = bearingCLFt * 12 + bearingCLIn;
     const bearingDistance = bearingDistanceFt * 12 + bearingDistanceIn;
+    const backwallClear = backwallClearanceIn;
+    const breastwallDist = breastwallDistanceFt * 12 + breastwallDistanceIn;
     
     // Set up scaling
     const scale = (canvas.width - 60) / totalLength;
@@ -168,29 +170,30 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
     
     const abutmentHeight = beamHeight * 1.5;
     const abutmentWidth = 20;
-    const abutmentBase = 30;
+    const abutmentBase = breastwallDist * scale;
     
     // Left abutment (L-shape)
+    const leftBackwallX = startX - backwallClear * scale;
     ctx.beginPath();
-    ctx.moveTo(startX - abutmentWidth, centerY - abutmentHeight / 2);
-    ctx.lineTo(startX, centerY - abutmentHeight / 2);
-    ctx.lineTo(startX, centerY + beamHeight / 2);
-    ctx.lineTo(startX - abutmentBase, centerY + beamHeight / 2);
-    ctx.lineTo(startX - abutmentBase, centerY + abutmentHeight / 2);
-    ctx.lineTo(startX - abutmentWidth, centerY + abutmentHeight / 2);
+    ctx.moveTo(leftBackwallX - abutmentWidth, centerY - abutmentHeight / 2);
+    ctx.lineTo(leftBackwallX, centerY - abutmentHeight / 2);
+    ctx.lineTo(leftBackwallX, centerY + beamHeight / 2);
+    ctx.lineTo(leftBackwallX - abutmentBase, centerY + beamHeight / 2);
+    ctx.lineTo(leftBackwallX - abutmentBase, centerY + abutmentHeight / 2);
+    ctx.lineTo(leftBackwallX - abutmentWidth, centerY + abutmentHeight / 2);
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
     
     // Right abutment (L-shape mirrored)
-    const rightX = startX + totalLength * scale;
+    const rightBackwallX = startX + totalLength * scale + backwallClear * scale;
     ctx.beginPath();
-    ctx.moveTo(rightX + abutmentWidth, centerY - abutmentHeight / 2);
-    ctx.lineTo(rightX, centerY - abutmentHeight / 2);
-    ctx.lineTo(rightX, centerY + beamHeight / 2);
-    ctx.lineTo(rightX + abutmentBase, centerY + beamHeight / 2);
-    ctx.lineTo(rightX + abutmentBase, centerY + abutmentHeight / 2);
-    ctx.lineTo(rightX + abutmentWidth, centerY + abutmentHeight / 2);
+    ctx.moveTo(rightBackwallX + abutmentWidth, centerY - abutmentHeight / 2);
+    ctx.lineTo(rightBackwallX, centerY - abutmentHeight / 2);
+    ctx.lineTo(rightBackwallX, centerY + beamHeight / 2);
+    ctx.lineTo(rightBackwallX + abutmentBase, centerY + beamHeight / 2);
+    ctx.lineTo(rightBackwallX + abutmentBase, centerY + abutmentHeight / 2);
+    ctx.lineTo(rightBackwallX + abutmentWidth, centerY + abutmentHeight / 2);
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
@@ -250,7 +253,7 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
   useEffect(() => {
     drawSectionPreview();
     drawElevationPreview();
-  }, [selectedProfile, lengthFt, lengthIn, bearingCLFt, bearingCLIn, bearingDistanceFt, bearingDistanceIn]);
+  }, [selectedProfile, lengthFt, lengthIn, bearingCLFt, bearingCLIn, bearingDistanceFt, bearingDistanceIn, backwallClearanceIn, breastwallDistanceFt, breastwallDistanceIn]);
   
   const handleApply = () => {
     // Update project info
@@ -273,7 +276,14 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
     // Update bearings
     const bearingDistance = bearingDistanceFt * 12 + bearingDistanceIn;
     setBearings(bearingDistance, bearingDistance);
-    
+
+    // Update abutments
+    const breastwallDistance = breastwallDistanceFt * 12 + breastwallDistanceIn;
+    setBeamDimensions({
+      backwallClearance: backwallClearanceIn,
+      breastwallDistance
+    });
+
     onClose();
   };
   

--- a/src/components/Toolbar/EditToolbar.tsx
+++ b/src/components/Toolbar/EditToolbar.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { useStore } from '../../store';
 import './Toolbar.css';
 
-export const EditToolbar: React.FC = () => {
+interface EditToolbarProps {
+  onConfigure: () => void;
+}
+
+export const EditToolbar: React.FC<EditToolbarProps> = ({ onConfigure }) => {
   const [activeTool, setActiveTool] = useState<string>('brush');
   const [activeCS, setActiveCS] = useState<number>(1);
   const [brushRadius, setBrushRadius] = useState<number>(1);
@@ -157,7 +161,12 @@ export const EditToolbar: React.FC = () => {
       
       <div className="tool-group ml-auto">
         {/* Configure button for advanced settings */}
-        <button className="action-btn" id="configure-btn" title="Advanced Settings">
+        <button
+          className="action-btn"
+          id="configure-btn"
+          title="Advanced Settings"
+          onClick={onConfigure}
+        >
           <svg width="16" height="16" viewBox="0 0 16 16">
             <circle cx="8" cy="8" r="3" stroke="currentColor" fill="none"/>
             <path d="M8 1 L8 3 M8 13 L8 15 M1 8 L3 8 M13 8 L15 8" stroke="currentColor"/>

--- a/src/scenes/MainSceneRefactored.ts
+++ b/src/scenes/MainSceneRefactored.ts
@@ -190,7 +190,10 @@ export class MainSceneRefactored extends Phaser.Scene {
     
     // Draw bearings
     this.drawBearings(scale);
-    
+
+    // Draw abutments
+    this.drawAbutments(scale);
+
     // Draw dimensions if enabled
     if (tool.showDimensions) {
       this.drawDimensions(scale);
@@ -227,6 +230,39 @@ export class MainSceneRefactored extends Phaser.Scene {
     );
     rightBearingGraphic.setStrokeStyle(2, bearingStroke);
     this.beamContainer.add(rightBearingGraphic);
+  }
+
+  private drawAbutments(scale: number) {
+    const { beam } = useStore.getState();
+    const { profile, length, backwallClearance, breastwallDistance, leftAbutmentHeight, rightAbutmentHeight } = beam;
+    if (!profile || breastwallDistance <= 0) return;
+
+    const abutmentColor = 0x666666;
+    const abutmentStroke = 0x444444;
+    const wallThickness = 10;
+    const baseThickness = 8;
+    const baseY = (profile.depth / 2) * scale;
+    const baseLength = breastwallDistance * scale;
+
+    // Left abutment
+    const leftBackwallX = -(length / 2 + backwallClearance) * scale;
+    const leftHeight = leftAbutmentHeight * scale;
+    const leftWall = this.add.rectangle(leftBackwallX, baseY - leftHeight / 2, wallThickness, leftHeight, abutmentColor);
+    leftWall.setStrokeStyle(2, abutmentStroke);
+    const leftBase = this.add.rectangle(leftBackwallX - baseLength / 2, baseY + baseThickness / 2, baseLength, baseThickness, abutmentColor);
+    leftBase.setStrokeStyle(2, abutmentStroke);
+    this.beamContainer.add(leftWall);
+    this.beamContainer.add(leftBase);
+
+    // Right abutment
+    const rightBackwallX = (length / 2 + backwallClearance) * scale;
+    const rightHeight = rightAbutmentHeight * scale;
+    const rightWall = this.add.rectangle(rightBackwallX, baseY - rightHeight / 2, wallThickness, rightHeight, abutmentColor);
+    rightWall.setStrokeStyle(2, abutmentStroke);
+    const rightBase = this.add.rectangle(rightBackwallX + baseLength / 2, baseY + baseThickness / 2, baseLength, baseThickness, abutmentColor);
+    rightBase.setStrokeStyle(2, abutmentStroke);
+    this.beamContainer.add(rightWall);
+    this.beamContainer.add(rightBase);
   }
 
   private drawDimensions(scale: number) {

--- a/src/store/canonical/refactoredTypes.ts
+++ b/src/store/canonical/refactoredTypes.ts
@@ -52,6 +52,10 @@ export interface CanonicalBeam {
   // Abutment heights (in inches)
   leftAbutmentHeight: number;
   rightAbutmentHeight: number;
+
+  // Abutment geometry
+  backwallClearance: number;
+  breastwallDistance: number;
   
   // Measurement units for display
   units: 'imperial' | 'metric';

--- a/src/store/canonical/types.ts
+++ b/src/store/canonical/types.ts
@@ -58,6 +58,10 @@ export interface CanonicalBeam {
   // Abutment heights
   leftAbutmentHeight: number;
   rightAbutmentHeight: number;
+
+  // Abutment geometry
+  backwallClearance: number;
+  breastwallDistance: number;
   
   // Measurement units
   units: 'imperial' | 'metric';

--- a/src/store/slices/beamSlice.ts
+++ b/src/store/slices/beamSlice.ts
@@ -24,6 +24,8 @@ export const createBeamSlice: StateCreator<
     rightBearing: 12,
     leftAbutmentHeight: 24,
     rightAbutmentHeight: 24,
+    backwallClearance: 2,
+    breastwallDistance: 30,
     units: 'imperial'
   },
   

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -18,6 +18,8 @@ export interface BeamState {
   rightBearing: number;
   leftAbutmentHeight: number;
   rightAbutmentHeight: number;
+  backwallClearance: number;
+  breastwallDistance: number;
   units: 'imperial' | 'metric';
 }
 

--- a/src/xml/deserializer.ts
+++ b/src/xml/deserializer.ts
@@ -90,6 +90,8 @@ export class XMLDeserializer {
       rightBearing: this.getNumberContent(node, 'right-bearing') || 12,
       leftAbutmentHeight: this.getNumberContent(node, 'left-abutment-height') || 24,
       rightAbutmentHeight: this.getNumberContent(node, 'right-abutment-height') || 24,
+      backwallClearance: this.getNumberContent(node, 'backwall-clearance') || 0,
+      breastwallDistance: this.getNumberContent(node, 'breastwall-distance') || 0,
       units
     };
   }

--- a/src/xml/serializer.ts
+++ b/src/xml/serializer.ts
@@ -105,6 +105,8 @@ export class XMLSerializer {
     lines.push(`${this.indent()}<right-bearing>${beam.rightBearing}</right-bearing>`);
     lines.push(`${this.indent()}<left-abutment-height>${beam.leftAbutmentHeight}</left-abutment-height>`);
     lines.push(`${this.indent()}<right-abutment-height>${beam.rightAbutmentHeight}</right-abutment-height>`);
+    lines.push(`${this.indent()}<backwall-clearance>${beam.backwallClearance}</backwall-clearance>`);
+    lines.push(`${this.indent()}<breastwall-distance>${beam.breastwallDistance}</breastwall-distance>`);
 
     this.indentLevel--;
     lines.push(`${this.indent()}</beam>`);


### PR DESCRIPTION
## Summary
- track backwall clearance and breastwall distance in beam state
- render L-shaped abutments and bearings in the Phaser scene
- persist new abutment fields through setup modal and XML I/O

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ddfe4e08c832591e8fc9f839925c0