### PR TITLE
Fix centerX reference and persist Map data

### DIFF
--- a/src/components/Setup/SetupModal.tsx
+++ b/src/components/Setup/SetupModal.tsx
@@ -152,6 +152,7 @@ export const SetupModal: React.FC<SetupModalProps> = ({ onClose }) => {
     // Set up scaling
     const scale = (canvas.width - 60) / totalLength;
     const centerY = canvas.height / 2;
+    const centerX = canvas.width / 2;
     const startX = 30;
     
     // Draw beam (side view)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -83,11 +83,26 @@ export const useStore = create<AppStore>()(
         partialize: (state) => ({
           project: state.project,
           beam: state.beam,
-          grid: state.grid,
+          grid: { ...state.grid, cells: Array.from(state.grid.cells.entries()) },
           tool: state.tool,
-          annotations: state.annotations,
+          annotations: {
+            ...state.annotations,
+            annotations: Array.from(state.annotations.annotations.entries())
+          },
           view: state.view
-        })
+        }),
+        deserialize: (str) => {
+          const data = JSON.parse(str);
+          if (data.state?.grid?.cells) {
+            data.state.grid.cells = new Map(data.state.grid.cells);
+          }
+          if (data.state?.annotations?.annotations) {
+            data.state.annotations.annotations = new Map(
+              data.state.annotations.annotations
+            );
+          }
+          return data;
+        }
       }
     )
   )


### PR DESCRIPTION
## Summary
- Define `centerX` in elevation preview to avoid ReferenceError
- Serialize/deserialize `Map` structures in persisted store

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e23a45d808325a92216b0df95b377