### PR TITLE
Render abutments with scaled geometry and improve grid interaction

### DIFF
--- a/src/scenes/MainSceneRefactored.ts
+++ b/src/scenes/MainSceneRefactored.ts
@@ -6,6 +6,11 @@ export class MainSceneRefactored extends Phaser.Scene {
   private gridContainer!: Phaser.GameObjects.Container;
   private beamContainer!: Phaser.GameObjects.Container;
   private gridRects: Map<string, Phaser.GameObjects.Rectangle> = new Map();
+  private gridCols = 0;
+  private gridRows = 0;
+  private gridStartX = 0;
+  private gridStartY = 0;
+  private currentGridSize = 0;
   private isDragging = false;
   private unsubscribe?: () => void;
   
@@ -79,10 +84,17 @@ export class MainSceneRefactored extends Phaser.Scene {
     // Calculate grid dimensions
     const cols = Math.ceil(length / gridSize);
     const rows = Math.ceil(beamDepth / gridSize);
-    
+
     // Center grid position
     const startX = -length / 2;
     const startY = -beamDepth / 2;
+
+    // Store for interaction calculations
+    this.gridCols = cols;
+    this.gridRows = rows;
+    this.gridStartX = startX;
+    this.gridStartY = startY;
+    this.currentGridSize = gridSize;
     
     // Clear existing grid
     this.gridContainer.removeAll(true);
@@ -103,9 +115,6 @@ export class MainSceneRefactored extends Phaser.Scene {
           gridSize
         );
         rect.setStrokeStyle(0.5, 0xcccccc);
-        rect.setInteractive();
-        rect.setData('row', row);
-        rect.setData('col', col);
         
         this.gridRects.set(key, rect);
         this.gridContainer.add(rect);
@@ -188,11 +197,11 @@ export class MainSceneRefactored extends Phaser.Scene {
     );
     this.beamContainer.add(bottomFlangeZone);
     
-    // Draw bearings
-    this.drawBearings(scale);
-
     // Draw abutments
     this.drawAbutments(scale);
+
+    // Draw bearings on top of abutments
+    this.drawBearings(scale);
 
     // Draw dimensions if enabled
     if (tool.showDimensions) {
@@ -204,32 +213,36 @@ export class MainSceneRefactored extends Phaser.Scene {
     const { beam } = useStore.getState();
     const { profile, length, leftBearing, rightBearing } = beam;
     if (!profile) return;
-    
-    // Complementary color for bearings (coral/salmon)
+
     const bearingColor = 0xFFA07A;
     const bearingStroke = 0x8B5A3C;
-    
-    const leftBearingGraphic = this.add.triangle(
-      -(length / 2 - leftBearing) * scale,
-      (profile.depth / 2 + 20) * scale,
-      0, 0,
-      -15 * scale, 30 * scale,
-      15 * scale, 30 * scale,
+    const bearingWidth = 6 * scale;
+    const bearingHeight = 2 * scale;
+    const seatY = (profile.depth / 2) * scale;
+
+    // Left bearing
+    const leftX = -(length / 2 - leftBearing) * scale;
+    const leftRect = this.add.rectangle(
+      leftX,
+      seatY + bearingHeight / 2,
+      bearingWidth,
+      bearingHeight,
       bearingColor
     );
-    leftBearingGraphic.setStrokeStyle(2, bearingStroke);
-    this.beamContainer.add(leftBearingGraphic);
-    
-    const rightBearingGraphic = this.add.triangle(
-      (length / 2 - rightBearing) * scale,
-      (profile.depth / 2 + 20) * scale,
-      0, 0,
-      -15 * scale, 30 * scale,
-      15 * scale, 30 * scale,
+    leftRect.setStrokeStyle(2, bearingStroke);
+    this.beamContainer.add(leftRect);
+
+    // Right bearing
+    const rightX = (length / 2 - rightBearing) * scale;
+    const rightRect = this.add.rectangle(
+      rightX,
+      seatY + bearingHeight / 2,
+      bearingWidth,
+      bearingHeight,
       bearingColor
     );
-    rightBearingGraphic.setStrokeStyle(2, bearingStroke);
-    this.beamContainer.add(rightBearingGraphic);
+    rightRect.setStrokeStyle(2, bearingStroke);
+    this.beamContainer.add(rightRect);
   }
 
   private drawAbutments(scale: number) {
@@ -237,32 +250,50 @@ export class MainSceneRefactored extends Phaser.Scene {
     const { profile, length, backwallClearance, breastwallDistance, leftAbutmentHeight, rightAbutmentHeight } = beam;
     if (!profile || breastwallDistance <= 0) return;
 
+    const baseY = (profile.depth / 2) * scale;
     const abutmentColor = 0x666666;
     const abutmentStroke = 0x444444;
-    const wallThickness = 10;
-    const baseThickness = 8;
-    const baseY = (profile.depth / 2) * scale;
-    const baseLength = breastwallDistance * scale;
 
-    // Left abutment
+    // Proportions based on design sketch
+    const frontOffsetRatio = 2 / 14;
+    const seatHeightRatio = 7 / 16;
+
+    const seatWidth = (breastwallDistance / 2) * scale;
+    const footingProjection = seatWidth * frontOffsetRatio;
+
+    const leftTotal = leftAbutmentHeight * scale;
+    const rightTotal = rightAbutmentHeight * scale;
+    const leftSeat = leftTotal * seatHeightRatio;
+    const rightSeat = rightTotal * seatHeightRatio;
+
+    const drawAbutment = (
+      backwallX: number,
+      seatHeight: number,
+      totalHeight: number,
+      direction: 1 | -1
+    ) => {
+      const g = this.add.graphics();
+      g.fillStyle(abutmentColor, 1);
+      g.lineStyle(2, abutmentStroke, 1);
+      g.beginPath();
+      g.moveTo(backwallX, baseY);
+      g.lineTo(backwallX, baseY + seatHeight);
+      g.lineTo(backwallX + direction * seatWidth, baseY + seatHeight);
+      g.lineTo(backwallX + direction * seatWidth, baseY + totalHeight);
+      g.lineTo(backwallX + direction * (seatWidth + footingProjection), baseY + totalHeight);
+      g.lineTo(backwallX + direction * (seatWidth + footingProjection), baseY);
+      g.closePath();
+      g.fillPath();
+      g.strokePath();
+      this.beamContainer.add(g);
+    };
+
+    // Left and right abutments
     const leftBackwallX = -(length / 2 + backwallClearance) * scale;
-    const leftHeight = leftAbutmentHeight * scale;
-    const leftWall = this.add.rectangle(leftBackwallX, baseY - leftHeight / 2, wallThickness, leftHeight, abutmentColor);
-    leftWall.setStrokeStyle(2, abutmentStroke);
-    const leftBase = this.add.rectangle(leftBackwallX - baseLength / 2, baseY + baseThickness / 2, baseLength, baseThickness, abutmentColor);
-    leftBase.setStrokeStyle(2, abutmentStroke);
-    this.beamContainer.add(leftWall);
-    this.beamContainer.add(leftBase);
+    drawAbutment(leftBackwallX, leftSeat, leftTotal, -1);
 
-    // Right abutment
     const rightBackwallX = (length / 2 + backwallClearance) * scale;
-    const rightHeight = rightAbutmentHeight * scale;
-    const rightWall = this.add.rectangle(rightBackwallX, baseY - rightHeight / 2, wallThickness, rightHeight, abutmentColor);
-    rightWall.setStrokeStyle(2, abutmentStroke);
-    const rightBase = this.add.rectangle(rightBackwallX + baseLength / 2, baseY + baseThickness / 2, baseLength, baseThickness, abutmentColor);
-    rightBase.setStrokeStyle(2, abutmentStroke);
-    this.beamContainer.add(rightWall);
-    this.beamContainer.add(rightBase);
+    drawAbutment(rightBackwallX, rightSeat, rightTotal, 1);
   }
 
   private drawDimensions(scale: number) {
@@ -317,11 +348,15 @@ export class MainSceneRefactored extends Phaser.Scene {
 
   private updateGridVisuals() {
     const { grid } = useStore.getState();
-    
+    const cells =
+      grid.cells instanceof Map
+        ? grid.cells
+        : new Map(Object.entries(grid.cells || {}));
+
     // Update all grid cells
     this.gridRects.forEach((rect, key) => {
-      const cell = grid.cells.get(key);
-      
+      const cell = cells.get(key);
+
       if (cell?.defectType) {
         const color = this.getDefectColor(cell.defectType, cell.severity!);
         rect.setFillStyle(color, 0.5);
@@ -409,21 +444,25 @@ export class MainSceneRefactored extends Phaser.Scene {
 
   private markAtPointer(pointer: Phaser.Input.Pointer) {
     const worldPoint = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
-    const gameObject = this.input.hitTestPointer(pointer)[0];
-    
-    if (gameObject && gameObject.getData) {
-      const row = gameObject.getData('row');
-      const col = gameObject.getData('col');
-      
-      if (row !== undefined && col !== undefined) {
-        const { tool, markCell } = useStore.getState();
-        
-        if (tool.selectedDefect === 'none') {
-          markCell(row, col);
-        } else {
-          markCell(row, col, tool.selectedDefect as DefectType, tool.selectedSeverity);
-        }
-      }
+
+    const col = Math.floor((worldPoint.x - this.gridStartX) / this.currentGridSize);
+    const row = Math.floor((worldPoint.y - this.gridStartY) / this.currentGridSize);
+
+    if (
+      row < 0 ||
+      col < 0 ||
+      row >= this.gridRows ||
+      col >= this.gridCols
+    ) {
+      return;
+    }
+
+    const { tool, markCell } = useStore.getState();
+
+    if (tool.selectedDefect === 'none') {
+      markCell(row, col);
+    } else {
+      markCell(row, col, tool.selectedDefect as DefectType, tool.selectedSeverity);
     }
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -80,26 +80,49 @@ export const useStore = create<AppStore>()(
       }),
       {
         name: 'visualbeam-storage',
-        partialize: (state) => ({
-          project: state.project,
-          beam: state.beam,
-          grid: { ...state.grid, cells: Array.from(state.grid.cells.entries()) },
-          tool: state.tool,
-          annotations: {
-            ...state.annotations,
-            annotations: Array.from(state.annotations.annotations.entries())
-          },
-          view: state.view
-        }),
+        partialize: (state) => {
+          const gridCells =
+            state.grid.cells instanceof Map
+              ? state.grid.cells
+              : new Map(Object.entries(state.grid.cells || {}));
+          const annotationMap =
+            state.annotations.annotations instanceof Map
+              ? state.annotations.annotations
+              : new Map(Object.entries(state.annotations.annotations || {}));
+
+          return {
+            project: state.project,
+            beam: state.beam,
+            grid: { ...state.grid, cells: Array.from(gridCells.entries()) },
+            tool: state.tool,
+            annotations: {
+              ...state.annotations,
+              annotations: Array.from(annotationMap.entries())
+            },
+            view: state.view
+          };
+        },
         deserialize: (str) => {
           const data = JSON.parse(str);
           if (data.state?.grid?.cells) {
-            data.state.grid.cells = new Map(data.state.grid.cells);
+            if (Array.isArray(data.state.grid.cells)) {
+              data.state.grid.cells = new Map(data.state.grid.cells);
+            } else {
+              data.state.grid.cells = new Map(
+                Object.entries(data.state.grid.cells)
+              );
+            }
           }
           if (data.state?.annotations?.annotations) {
-            data.state.annotations.annotations = new Map(
-              data.state.annotations.annotations
-            );
+            if (Array.isArray(data.state.annotations.annotations)) {
+              data.state.annotations.annotations = new Map(
+                data.state.annotations.annotations
+              );
+            } else {
+              data.state.annotations.annotations = new Map(
+                Object.entries(data.state.annotations.annotations)
+              );
+            }
           }
           return data;
         }

--- a/src/store/slices/gridSlice.ts
+++ b/src/store/slices/gridSlice.ts
@@ -2,6 +2,9 @@ import { StateCreator } from 'zustand';
 import { AppStore, GridState, CellState } from '../types';
 import { DefectType } from '../../types';
 
+const toMap = (cells: any): Map<string, CellState> =>
+  cells instanceof Map ? cells : new Map(Object.entries(cells || {}));
+
 export interface GridSlice {
   grid: GridState;
   setGridSize: (size: number) => void;
@@ -33,7 +36,7 @@ export const createGridSlice: StateCreator<
       
       // Remap cells to new grid
       const newCells = new Map<string, CellState>();
-      state.grid.cells.forEach((cell) => {
+      toMap(state.grid.cells).forEach((cell) => {
         // Calculate position in new grid
         const oldY = cell.row * state.grid.size;
         const oldX = cell.col * state.grid.size;
@@ -70,7 +73,7 @@ export const createGridSlice: StateCreator<
   markCell: (row, col, defect, severity) =>
     set((state) => {
       const key = `${row},${col}`;
-      const cells = new Map(state.grid.cells);
+      const cells = new Map(toMap(state.grid.cells));
       
       if (!defect) {
         cells.delete(key);
@@ -96,7 +99,7 @@ export const createGridSlice: StateCreator<
   clearCell: (row, col) =>
     set((state) => {
       const key = `${row},${col}`;
-      const cells = new Map(state.grid.cells);
+      const cells = new Map(toMap(state.grid.cells));
       cells.delete(key);
       
       return {


### PR DESCRIPTION
## Summary
- Normalize grid cell storage when persisting and loading state to avoid runtime failures
- Convert grid cell collections to Maps inside slice methods and when rendering the grid
- Guard grid rendering against non-Map data to prevent empty canvas on configuration apply

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Property 'setBeamLength' does not exist on type 'AppStore', etc.)*
- `npx eslint src/scenes/MainSceneRefactored.ts` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Failed to resolve entry for package "react-dom")*


------
https://chatgpt.com/codex/tasks/task_e_689f1b215cb883259dcc1e20a6532e7e